### PR TITLE
Add Support for POST Requests

### DIFF
--- a/lib/readability/client.rb
+++ b/lib/readability/client.rb
@@ -9,11 +9,16 @@ module Readability
       @token = token.dup
 
       # get available resource types
-      @resources = get
+      @resources = request
     end
 
-    def get(resource="", args={})
-      response = @token.get(format_query(resource, args))
+    def request(resource="", args={}, body={})
+      if body == {}
+        response = @token.get(format_query(resource, args))
+      else
+        response = @token.post(format_query(resource, args), parameterize(body),
+                               { 'Content-Type' => 'application/x-www-form-urlencoded' })
+      end
       case response
         when Net::HTTPSuccess
           data = JSON.parse(response.body)
@@ -23,6 +28,7 @@ module Readability
         raise StandardError, "Could not get data for those params."
       end
     end
+    alias :get :request
 
     def format_query(resource, args)
       options = args.dup

--- a/lib/readability/helpers/authentication.rb
+++ b/lib/readability/helpers/authentication.rb
@@ -9,8 +9,8 @@ module Readability
         session[:readability][:readability_access] if session[:readability]
       end
 
-      def readability(resource, args = {})
-        readability_client.get(resource, args)
+      def readability(resource, args = {}, body = {})
+        readability_client.request(resource, args, body)
       end
 
       def dereadabilify


### PR DESCRIPTION
I added support for POST requests by extending the readability method with a hash argument for the request body. The POST method will be used if a non-empty hash is passed as the third argument, otherwise GET is used as in the original implementation.
